### PR TITLE
fix(fix proxy error while building docker):

### DIFF
--- a/ubuntu2004/Makefile
+++ b/ubuntu2004/Makefile
@@ -1,5 +1,5 @@
 all:
-	docker build -f Dockerfile -t build-in-ubuntu-2204 .
+	docker build --network=host -f Dockerfile -t build-in-ubuntu-2204 .
 	rm -rf output && mkdir -p output
 	docker run --rm -it -v $$PWD/output:/home/build/output build-in-ubuntu-2204 cp -r podman_image/tmpWorkSpace /home/build/output/
 	docker build -f ../podman_image/Containerfile.misrac100k4 -t naive.systems/analyzer/misra:dev_en ./output/tmpWorkSpace


### PR DESCRIPTION
fix proxy while building docker for ubuntu2004:
```
➜  ubuntu2004 git:(master) make    
docker build -f Dockerfile -t build-in-ubuntu-2204 .
[+] Building 4.3s (2/3)                                                                                                                                                                                                 docker:default
[+] Building 4.5s (2/3)                                                                                                                                                                                                 docker:default
[+] Building 10.1s (3/3) FINISHED                                                                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                              0.0s
 => => transferring dockerfile: 32B                                                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                 0.0s
 => => transferring context: 2B                                                                                                                                                                                                   0.0s
 => ERROR [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                                                            10.0s
------
 > [internal] load metadata for docker.io/library/ubuntu:22.04:
------
ERROR: failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: failed to do request: Head "https://d99f6be0.m.daocloud.io/v2/library/ubuntu/manifests/22.04?ns=docker.io": dial tcp: lookup d99f6be0.m.daocloud.io on 127.0.0.53:53: no such host
make: *** [Makefile:2: all] Error 1

```